### PR TITLE
Moved maven-shade-plugin to endUserRelease profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+dependency-reduced-pom.xml
+target/*

--- a/pom.xml
+++ b/pom.xml
@@ -126,29 +126,6 @@
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <version>2.1</version>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                        <configuration>
-                            <!-- Set to false because codec classes were missing. -->
-                            <minimizeJar>false</minimizeJar>
-                            <transformers>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
-                                    <resource>META-INF/services/org.apache.lucene.codecs.Codec</resource>
-                                </transformer>
-                            </transformers>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
                 <version>2.2.2</version>
                 <configuration>
@@ -192,6 +169,35 @@
                                 <goals>
                                     <goal>sign</goal>
                                 </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>endUserRelease</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-shade-plugin</artifactId>
+                        <version>2.1</version>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>shade</goal>
+                                </goals>
+                                <configuration>
+                                    <!-- Set to false because codec classes were missing. -->
+                                    <minimizeJar>false</minimizeJar>
+                                    <transformers>
+                                        <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                                            <resource>META-INF/services/org.apache.lucene.codecs.Codec</resource>
+                                        </transformer>
+                                    </transformers>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>


### PR DESCRIPTION
As discussed on mailing list 21-24 March 2015, this change makes the default SV build construct non-shaded JARs, in turn enabling developers to reuse these JARs in a modular fashion (e.g., with their build system resolving dependencies and allowing the devs to override or adapt them). In order to build a shaded uber-jar suitable for end-user release (e.g., direct download rather than Maven Central distribution), simply add the "-P endUserRelease" options to the maven command when building.

I've also added some paths to the .gitignore file, so that generated artefacts don't risk ending up in the Git repository.